### PR TITLE
Remove lsof

### DIFF
--- a/device/peripherals/modules/camera/drivers/base_driver.py
+++ b/device/peripherals/modules/camera/drivers/base_driver.py
@@ -1,3 +1,4 @@
+import datetime
 from abc import ABC, abstractmethod
 
 import threading, os
@@ -31,6 +32,7 @@ class CameraDriver(ABC):
 
         # universal paths
         self.IMAGE_DIR = settings.DATA_PATH + "/images/"
+        self.CAPTURE_DIR = self.IMAGE_DIR + "capture/"
         self.MODULE_DIR = "device/peripherals/modules/usb_camera/"
         self.SIMULATE_IMAGE_DIR = self.MODULE_DIR + "tests/images/"
         self.DUMMY_IMAGE_PATH = self.MODULE_DIR + "dummy.png"
@@ -59,10 +61,14 @@ class CameraDriver(ABC):
             self.usb_mux_enabled = False
         else:
             self.directory = self.IMAGE_DIR
+            self.capture_dir = self.CAPTURE_DIR
 
             # Check directory exists else create it
             if not os.path.exists(self.directory):
                 os.makedirs(self.directory)
+
+            if not os.path.exists(self.capture_dir):
+                os.makedirs(self.capture_dir)
 
             # Check if using usb mux
             if usb_mux_comms is None \
@@ -107,7 +113,10 @@ class CameraDriver(ABC):
     @abstractmethod
     def capture(self, retry: bool = True) -> None:
         """Captures an image from a camera or set of non-unique cameras."""
-        self.logger.debug("Capturing")
+        timestring = datetime.datetime.utcnow().strftime("%Y-%m-%d_T%H-%M-%SZ")
+        # filename = self.directory + "{}_{}.png".format(timestring, self.name)
+        filename = "{}_{}.png".format(timestring, self.name)
+        self.logger.info(f"Capturing {filename}")
         return
 
     def _simulate_capture(self, filename: str) -> bool:

--- a/device/peripherals/modules/camera/drivers/picam_driver.py
+++ b/device/peripherals/modules/camera/drivers/picam_driver.py
@@ -2,6 +2,7 @@ import threading
 import os
 import datetime
 import time
+import shutil
 
 from typing import Optional, Dict, Any
 
@@ -58,7 +59,8 @@ class PiCameraDriver(CameraDriver):
         super().capture(retry=retry)
 
         timestring = datetime.datetime.utcnow().strftime("%Y-%m-%d_T%H-%M-%SZ")
-        filename = self.directory + "{}_{}.png".format(timestring, self.name)
+        #filename = self.directory + "{}_{}.png".format(timestring, self.name)
+        filename = "{}_{}.png".format(timestring, self.name)
 
         # Check if simulated
         # if self.simulate:
@@ -77,7 +79,9 @@ class PiCameraDriver(CameraDriver):
             time.sleep(2)
             # Get timestring in ISO8601 format
             self.logger.debug("Captureing " + filename)
-            self.camera.capture(filename)
+            self.camera.capture(self.capture_dir + filename)
             self.camera.stop_preview()
+            self.logger.debug("Moving captured image")  # This prevents trying to upload while still capturing
+            shutil.move(self.capture_dir + filename, self.directory + filename)
 
         return

--- a/device/peripherals/modules/camera/drivers/usb_camera_driver.py
+++ b/device/peripherals/modules/camera/drivers/usb_camera_driver.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import shutil
 import threading
 import time
 from typing import Optional, Dict, Any
@@ -134,10 +135,12 @@ class USBCameraDriver(CameraDriver):
                 filename = "{}_{}.{}.png".format(timestring, self.name, index + 1)
 
             # Create image path
-            image_path = self.directory + filename
+            capture_image_path = self.capture_dir + filename
+            final_image_path = self.directory + filename
 
             # Capture image
-            self.capture_image_pygame(camera_path, image_path)
+            self.capture_image_pygame(camera_path, capture_image_path)
+            shutil.move(capture_image_path, final_image_path)
 
     def capture_image_pygame(self, camera_path: str, image_path: str) -> None:
         """Captures an image with pygame."""

--- a/device/peripherals/modules/camera/manager.py
+++ b/device/peripherals/modules/camera/manager.py
@@ -33,6 +33,7 @@ class CameraManager(manager.PeripheralManager):  # type: ignore
         # Initialize sampling parameters
         self.min_sampling_interval = 120  # seconds
         self.default_sampling_interval = 3600  # every hour
+        # self.default_sampling_interval = 299  # every ~5 mins for testing
 
         # Initialize light control parameters
         self.lighting_control = self.parameters.get("lighting_control", {})


### PR DESCRIPTION
Remove the need for using the shell command lsof to insure that an image is complete before trying to upload the image. (On RPi this would error out, but the code didn't recognize it, then the image would be deleted. It is better to just remove this requirement.) Instead the images are saved to 'images/capture/' while being captured, then once the process is completed they get moved up to images where the IoTManager will find and process them. The USB camera driver (using pygame) has been modified to mimic the behavior, but has not been tested.