### PR TITLE
Iot reconnect fix

### DIFF
--- a/device/iot/manager.py
+++ b/device/iot/manager.py
@@ -330,8 +330,8 @@ class IotManager(manager.StateMachineManager):
         """Runs connected mode."""
         self.logger.info("Entered CONNECTED")
 
-        # Subscribe to topics
-        self.pubsub.subscribe_to_topics()
+        # Subscribe to topics # This is handled in the on_connect callback
+        # self.pubsub.subscribe_to_topics()
 
         # Publish a boot message
         self.publish_boot_message()
@@ -798,6 +798,7 @@ def on_connect(
 ) -> None:
     """Callback for when a device connects to mqtt broker."""
     ref_self.is_connected = True
+    ref_self.pubsub.subscribe_to_topics()  # We need to resubscribe everytime we re-connect.
 
 def on_disconnect(client: mqtt.Client, ref_self: IotManager, return_code: int) -> None:
     """Callback for when a device disconnects from mqtt broker."""

--- a/device/iot/pubsub.py
+++ b/device/iot/pubsub.py
@@ -174,7 +174,7 @@ class PubSub:
         # Check if json webtoken is expired, if so renew client
         if self.json_web_token.is_expired:
             self.create_mqtt_client()  # TODO: Renew instead of re-create
-            self.subscribe_to_topics()
+            # self.subscribe_to_topics() # Handled on the on_connect callback
 
         # Update mqtt client
         try:


### PR DESCRIPTION
Moved subscribing to topics into the on connect handler rather than calling it directly.
If the mqtt server disconnects, we now detect that, and move the IoT manager into disconnected mode. (This should reconnect once the server comes back up.)