### PR TITLE
Finished up manual fan control (on local mqtt stuff)

### DIFF
--- a/device/peripherals/common/adt7470/driver.py
+++ b/device/peripherals/common/adt7470/driver.py
@@ -487,3 +487,5 @@ class ADT7470Driver:
                 self.i2c.write_register(CONFIG_REGISTER_2, register_byte)
             except I2CError as e:
                 raise exceptions.ShutdownError(logger=self.logger) from e
+
+

--- a/device/peripherals/modules/controller_adt7470/events.py
+++ b/device/peripherals/modules/controller_adt7470/events.py
@@ -1,0 +1,3 @@
+TURN_ON = "Turn On"
+TURN_OFF = "Turn Off"
+SET_DUTY_CYCLE = "Set Duty Cycle"

--- a/device/peripherals/modules/controller_adt7470/setups/single_sensor_single_fan.json
+++ b/device/peripherals/modules/controller_adt7470/setups/single_sensor_single_fan.json
@@ -18,13 +18,13 @@
 		"actuators": [
 			{
 				"duty_cycle_name": "heat_sink_fan_duty_cycle_percent",
-        "fan_speed_name": "heat_sink_fan_speed_rpm",
+        		"fan_speed_name": "heat_sink_fan_speed_rpm",
 				"fan_id": 0,
 				"control_sensor_id": 0,
 				"minimum_temperature": 40,
 				"minimum_duty_cycle": 5,
-        "maximum_duty_cycle": 100,
-        "drive_frequency_mode": "low"
+        		"maximum_duty_cycle": 100,
+        		"drive_frequency_mode": "low"
 			}
 		],
 		"communication": {
@@ -76,18 +76,28 @@
 	    },
 	    {
 	        "name": "Turn On",
-	        "description": "Turns on heater.",
+	        "description": "Turns on fan.",
 	        "value": null,
 	        "sequence": null,
 	        "is_manual": true
 	    },
 	    {
 	        "name": "Turn Off",
-	        "description": "Turns off heater.",
+	        "description": "Turns off fan.",
 	        "value": null,
 	        "sequence": null,
 	        "is_manual": true
-	    }
+	    },
+		{
+			"name": "Set Duty Cycle",
+			"description": "Set the duty cycle for the fan 0-100%",
+			"value": {
+				"default": "50",
+				"units": "Percent"
+			},
+			"sequence": null,
+			"is_manual": true
+		}
 	],
 	"info": {
 		"variables": {


### PR DESCRIPTION
Added in ability to turn the heatsink fan controller onto manual where you can specify a duty cycle to run. This is due to some of the temperature sensors being damaged in reflow, so they are not reliable for setting the fan speed. 